### PR TITLE
fix mirroring worker issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,6 @@ on:
     branches: [ "main" ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +20,8 @@ jobs:
       with:
         go-version: '1.24.5'
 
+    - name: Install dependencies
+      run: go mod tidy
     - name: Build
       run: go build -v ./...
 

--- a/cmd/mirror.go
+++ b/cmd/mirror.go
@@ -54,7 +54,6 @@ type mirrorStats struct {
 }
 
 // InitMirroring initializes the mirroring process for the given startURL.
-// It parses the URL, creates the output directory, and sets up rejection rules.
 func InitMirroring(startURL string) error {
 	parsed, err := url.Parse(startURL)
 	if err != nil {
@@ -68,7 +67,7 @@ func InitMirroring(startURL string) error {
 
 	var rej []string
 	if MirrorFlagsConfig.Reject != "" {
-		for e := range strings.SplitSeq(MirrorFlagsConfig.Reject, ",") {
+		for _, e := range strings.Split(MirrorFlagsConfig.Reject, ",") {
 			e = strings.TrimSpace(e)
 			if e == "" {
 				continue
@@ -79,9 +78,10 @@ func InitMirroring(startURL string) error {
 			rej = append(rej, strings.ToLower(e))
 		}
 	}
+
 	var excl []string
 	if MirrorFlagsConfig.Exclude != "" {
-		for d := range strings.SplitSeq(MirrorFlagsConfig.Exclude, ",") {
+		for _, d := range strings.Split(MirrorFlagsConfig.Exclude, ",") {
 			d = strings.Trim(strings.TrimSpace(d), "/")
 			if d != "" {
 				excl = append(excl, d)
@@ -92,12 +92,13 @@ func InitMirroring(startURL string) error {
 	var rootCtx context.Context
 	var cancel context.CancelFunc
 	if MirrorFlagsConfig.Timeout > 0 {
-		rootCtx, cancel = context.WithTimeout(context.Background(), time.Duration(MirrorFlagsConfig.Timeout)*time.Second)
+		rootCtx, cancel = context.WithTimeout(context.Background(),
+			time.Duration(MirrorFlagsConfig.Timeout)*time.Second)
 	} else {
 		rootCtx, cancel = context.WithCancel(context.Background())
 	}
 
-	client := &http.Client{Timeout: 0}
+	client := &http.Client{Timeout: 30 * time.Second}
 
 	m := &mirror{
 		baseURL:     parsed,
@@ -115,7 +116,8 @@ func InitMirroring(startURL string) error {
 	}
 	m.stats.start = time.Now()
 
-	fmt.Printf("Mirroring %s -> %s/ (depth=%d, convert=%v)\n", startURL, m.outputDir, m.maxDepth, m.convert)
+	fmt.Printf("Mirroring %s -> %s/ (depth=%d, convert=%v)\n",
+		startURL, m.outputDir, m.maxDepth, m.convert)
 	if len(rej) > 0 {
 		fmt.Printf("Reject: %s\n", strings.Join(rej, ","))
 	}
@@ -143,7 +145,12 @@ func InitMirroring(startURL string) error {
 	for i := 0; i < m.workers; i++ {
 		wg.Add(1)
 		go func(id int) {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("worker %d panicked: %v", id, r)
+				}
+				wg.Done()
+			}()
 			m.workerLoop(id)
 		}(i + 1)
 	}


### PR DESCRIPTION
 fixed several issues in the mirroring implementation.

- Aligns with Go community best practices
- Prevents runtime panics and infinite hangs
- Improves stability and readability of the mirroring feature

### Testing
- Verified `go build` compiles successfully
- Ran mirroring against test websites; workers now recover safely and stop cleanly

Closes #14 